### PR TITLE
On index.js: using MDN recommendations for Prototype manipulation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ class BigCoffee {
     context = context || document
 
     const elements = context.querySelectorAll(selector)
-    elements.__proto__ = BigCoffee.methods
+    elements.setPrototypeOf(BigCoffee.methods)
 
     return elements
   }


### PR DESCRIPTION
Changed the setting of __proto__ property to .setPrototypeOf according to MDN recommendations, as stated at the third warning at [this link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto).